### PR TITLE
docs: fix docs for project rename

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # vuex-sync-store
 
-[![CircleCI](https://circleci.com/gh/galenwarren/sync-store/tree/master.svg?style=svg)](https://circleci.com/gh/galenwarren/sync-store/tree/master)
+[![CircleCI](https://circleci.com/gh/galenwarren/vuex-sync-store/tree/master.svg?style=svg)](https://circleci.com/gh/galenwarren/vuex-sync-store/tree/master)
 [![tested with jest](https://img.shields.io/badge/tested_with-jest-99424f.svg)](https://github.com/facebook/jest)
-[![Coverage Status](https://img.shields.io/coveralls/github/galenwarren/sync-store/master.svg)](https://coveralls.io/github/galenwarren/sync-store)
+[![Coverage Status](https://coveralls.io/repos/github/galenwarren/vuex-sync-store/badge.svg?branch=master)](https://coveralls.io/github/galenwarren/vuex-sync-store?branch=master)
 [![semantic-release](https://img.shields.io/badge/%20%20%F0%9F%93%A6%F0%9F%9A%80-semantic--release-e10079.svg)](https://github.com/semantic-release/semantic-release)
 [![Commitizen friendly](https://img.shields.io/badge/commitizen-friendly-brightgreen.svg)](http://commitizen.github.io/cz-cli/)
 


### PR DESCRIPTION
Vuepress needs to have the proper project name as base to host on GitHub pages